### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ These client functions are computed from the API and manage serialization, XhrRe
    -- No need to write these functions. servant-reflex creates them for you!
    getint :: MonadWidget t m
           => Event t ()  -- ^ Trigger the XHR Request
-          -> m (Event t (Maybe (Int, XhrResponse))) -- ^ Consume the answer
+          -> m (Event t (Maybe Int, XhrResponse)) -- ^ Consume the answer
 
    sayhi :: MonadWidget t m
          => Behavior t (Maybe String) -- ^ One input parameter - the 'name'


### PR DESCRIPTION
From my experiments of this afternoon, the correct return type of API client functions should be `m (Event t (Maybe a, XhrResponse))` rather than `m (Event t (Maybe (a, XhrResponse)))`.

You can just close the PR if I’m wrong, though.